### PR TITLE
I changed Monokai address to .dvtcolortheme extension

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -111,7 +111,7 @@
       },
       {
         "name": "Monokai",
-        "url": "https://raw.github.com/mclaughj/Monokai-Xcode-Theme/master/Monokai.xccolortheme",
+        "url": "https://raw.github.com/mclaughj/Monokai-Xcode-Theme/master/Monokai.dvtcolortheme",
         "description": "A simple port of the Monokai TextMate theme to Xcode"
       },
       {


### PR DESCRIPTION
I'm pretty sure XCode 4 requires the *.dvtcolortheme extension, that's probably why it didn't work for me.  Should work now.
