### PR TITLE
Add DocExpander plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -101,6 +101,11 @@
         "name": "DLAutoresizeMaskPlugin",
         "url": "https://github.com/garnett/AutoresizeMask-for-Xcode",
         "description": "Vizualize autoresizing masks in the code editor."
+      },
+      {
+        "name": "DocExpander",
+        "url": "https://github.com/bjtitus/XcodeDocExpander",
+        "description": "Intelligent comment expansion based on DocBlockr for Sublime Text."
       }
     ],
     "color_schemes": [


### PR DESCRIPTION
This is a very simple plugin I wrote to emulate [DocBlockr](https://github.com/spadgos/sublime-jsdocs) for comment generation.
