### PR TITLE
Fix inverted url and description for project template 'Minimal'

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -233,8 +233,8 @@
       },
       {
         "name": "Minimal",
-        "url": "Minimalistic, nib-less templates for Xcode 4",
-        "description": "https://github.com/omz/MinimalisticXcodeTemplates"
+        "url": "https://github.com/omz/MinimalisticXcodeTemplates",
+        "description": "Minimalistic, nib-less templates for Xcode 4"
       }
     ],
     "file_templates": [


### PR DESCRIPTION
Maybe checking the urls are valid could be done in the rspec thingy (I'd propose a patch, but I never used it).
