### PR TITLE
Improve the Xprop plugin description

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -98,7 +98,7 @@
         "description": "Close the debug window automatically after the debug session has ended."
       },
       {
-        "name": "Hide @property @synthesize",
+        "name": "Xprop — hide @synthesizers from popup",
         "url": "https://github.com/shpakovski/Xprop",
         "description": "Exclude @property and @synthesize document items from the navigator menu."
       },


### PR DESCRIPTION
The name Xprop is almost meaningless, so I think it is better to expand it in the packages table view.
