### PR TITLE
Added new plugin: BTGisterPost

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -147,7 +147,7 @@
         "name": "XcodeExplorer",
         "url": "https://github.com/edwardaux/XcodeExplorer",
         "description": "This is a plugin project that allows you, as a developer, to explore the various events and notifications that Xcode4 emits during normal operations."
-      }
+      },
       {
         "name": "BTGisterPost",
         "url": "https://github.com/LogikBlitz/BTGisterPost",


### PR DESCRIPTION
https://github.com/LogikBlitz/BTGisterPost Allows for posting of GitHub gist's directly from Xcode.
