### PR TITLE
Add FuzzyAutocomplete to plugin list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -197,6 +197,12 @@
         "name": "XcodeColors",
         "url": "https://github.com/robbiehanson/XcodeColors.git",
         "description": "XcodeColors allows you to use colors in the Xcode debugging console. It's designed to aid in the debugging process."
+      },
+      {
+        "name": "FuzzyAutocomplete",
+        "url": "https://github.com/chendo/FuzzyAutocompletePlugin",
+        "description": "Enables fuzzy matching in Xcode's autocomplete, using the 'Open Quickly' algorithm.",
+        "screenshot": "https://raw.github.com/chendo/FuzzyAutocompletePlugin/master/demo.gif"
       }
     ],
     "color_schemes": [


### PR DESCRIPTION
This PR adds FuzzyAutocomplete (https://github.com/chendo/FuzzyAutocompletePlugin) to the plugin list. Here's hoping Alcatraz supports GIFs!
