### PR TITLE
Injection Plugin not installing correctly

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -177,12 +177,6 @@
         "screenshot": "https://raw.github.com/payliu/XcodePlus/master/screenshot/deleteline.gif"
       },
       {
-        "name": "InjectionPlugin",
-        "url": "https://github.com/johnno1962/injectionforxcode",
-        "description": "Inject code changes directly into your running application.",
-        "screenshot": "http://johnholdsworth.com/injection/demo.png"
-      },
-      {
         "name": "XcodeColors",
         "url": "https://github.com/robbiehanson/XcodeColors.git",
         "description": "XcodeColors allows you to use colors in the Xcode debugging console. It's designed to aid in the debugging process."


### PR DESCRIPTION
Hi, it’s possible you may have to remove my plugin as it is not installing properly in Alcatraz since changes I made yesterday. It now has a bundle subproject meaning the Plugin project needs to be built for the "iOS simulator". Are there Alcatraz logs I can look at to find out what the problem is?
