### PR TITLE
Add Eero Language plugin and templates support.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -254,7 +254,7 @@
       {
         "name": "Eero Xcode",
         "url": "https://github.com/eerolanguage/eero-installer-for-alcatraz",
-        "description": "Eero Programming Language integration with Xcode. Please restart Xcode after installing!",
+        "description": "Eero Programming Language support. Please restart Xcode after installing!",
         "screenshot": "http://eerolanguage.org/images/HelloWorld.png"
       }
     ],


### PR DESCRIPTION
The plugin project is actually a sort of meta-project that installs the latest support binaries. All of the code itself is open source and on github (referenced in readme), however. I did it this way because the regular plugin requires building a fork of LLVM and clang, which is no small task. I've tested this locally, but please let me know if you run into any problems or would like me to take a different approach. Thanks!
