### PR TITLE
Adds Atom Light color scheme based on default theme from Atom.io.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -605,9 +605,9 @@
       },
       {
         "name" : "Atom Light",
-        "url" : "https://github.com/paulpilone/xcode-themes/blob/master/AtomLight.dvtcolortheme",
+        "url" : "https://raw.github.com/paulpilone/xcode-themes/master/AtomLight.dvtcolortheme",
         "description" : "A light theme based on the default theme from Atom.io.",
-        "screenshot" : "https://github.com/paulpilone/xcode-themes/blob/master/AtomLight.png"
+        "screenshot" : "https://raw.githubusercontent.com/paulpilone/xcode-themes/master/AtomLight.png"
       }
     ],
     "project_templates": [


### PR DESCRIPTION
Simple color scheme based on the default light theme of Atom.io. I've been jumping between editors and I really enjoy this theme.
