### PR TITLE
Open in Terminal - Xcode Plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -338,12 +338,12 @@
         "description": "Plugin for Xcode to optimize images using ImageOptim.",
         "screenshot": "https://raw.githubusercontent.com/yeahdongcn/RSImageOptimPlugin/master/ImageOptim-screenshot@2x.png"
       },
-	  {
-          "name": "WCGitTagsPlugin",
-          "url": "https://github.com/wczekalski/WCGitTagsPlugin",
-          "description": "Add tagging ability to Xcode Source Control",
-          "screenshot": "https://raw.githubusercontent.com/wczekalski/WCGitTagsPlugin/master/Resources/revealed.png"
-	  },
+      {
+      	"name": "WCGitTagsPlugin",
+      	"url": "https://github.com/wczekalski/WCGitTagsPlugin",
+      	"description": "Add tagging ability to Xcode Source Control",
+      	"screenshot": "https://raw.githubusercontent.com/wczekalski/WCGitTagsPlugin/master/Resources/revealed.png"
+      },
       {
         "name": "OpenInTerminal",
         "url": "https://github.com/sathya-me/OpenInTerminal.git",


### PR DESCRIPTION
Open In Terminal is a plugin for xcode to open the selected file's directory in terminal. This helps you to easily reach the current active file in terminal.

![demo](https://cloud.githubusercontent.com/assets/1215654/3016730/7a1db842-df71-11e3-99d5-3e2bd734d17d.png)
