### PR TITLE
Added DebugSearch to the packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -371,6 +371,11 @@
       "url": "https://github.com/jcavar/xcfui",
       "description": "Xcode plugin for fui tool",
       "screenshot": "https://raw.githubusercontent.com/jcavar/xcfui/master/preview.png"
+     },
+     {
+      "name": "DebugSearch",
+      "url": "https://github.com/maranas/DebugSearch",
+      "description": "Xcode plugin to allow filtering of console messages"
      }
     ],
     "color_schemes": [


### PR DESCRIPTION
Hi, I just added DebugSearch to the package list. It's a plugin that enables filtering of debug messages in the console, Eclipse-style.
