### PR TITLE
explicitly use should syntax for rspec

### DIFF
--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -2,6 +2,12 @@ require 'rspec'
 require 'json'
 require 'uri'
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :should
+  end
+end
+
 describe "Packages" do
 
   before do


### PR DESCRIPTION
Using `should` syntax without specifying it is deprecated. This leads to the question if we should use the `expect` syntax instead, I know @supermarin doesn't like it though so I'm totally fine with this too.
