### PR TITLE
Move cocoa controls plugin from file_templates section to plugin section

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -478,6 +478,12 @@
         "name": "MarvinPlugin",
         "url": "https://github.com/zenangst/MarvinXcode",
         "description": "A collection of nifty commands for your everyday workflow in Xcode"
+      },
+      {
+        "name": "CocoaControls",
+        "url": "https://github.com/yeahdongcn/CocoaControlsPlugin/tree/master/CocoaControls",
+        "description": "Plugin for Xcode to browse, search, integrate, clone controls in http://cocoacontrols.com/.",
+        "screenshot": "https://raw.githubusercontent.com/yeahdongcn/CocoaControlsPlugin/master/app_screenshot.png"
       }
     ],
     "color_schemes": [
@@ -907,12 +913,6 @@
         "url": "https://github.com/Daij-Djan/MiniXcode",
         "description": "Plugin that makes it easier to run Xcode without the main toolbar.",
         "screenshot": "https://raw.githubusercontent.com/Daij-Djan/MiniXcode/master/Screenshot.png"
-      },
-      {
-        "name": "CocoaControls",
-        "url": "https://github.com/yeahdongcn/CocoaControlsPlugin/tree/master/CocoaControls",
-        "description": "Plugin for Xcode to browse, search, integrate, clone controls in http://cocoacontrols.com/.",
-        "screenshot": "https://raw.githubusercontent.com/yeahdongcn/CocoaControlsPlugin/master/app_screenshot.png"
       }
     ]
   }


### PR DESCRIPTION
Just realized I have put this plugin to wrong section, sorry about the inconvenience.
