### PR TITLE
Add ProjectWindowName plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2,6 +2,11 @@
   "packages": {
     "plugins": [
       {
+       "name": "ProjectWindowName",
+       "url": "https://github.com/sleifer/ProjectWindowName",
+       "description": "Prepend project name to window title for Xcode Project and Workspace windows."
+      },
+      {
        "name": "Aviator",
        "url": "https://github.com/marksands/Aviator",
        "description": "Adds the AppCode shortcut shift+command+T to toggle between a source file and its test file counterpart."


### PR DESCRIPTION
I'd like to add the plugin I created to Alcatraz's catalog. The plugin prepend the current projects name to the window title.
