### PR TITLE
Remove AFNetworking Project Templates

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -850,11 +850,6 @@
         "description": "Setup for your AeroGear projects, based on CocoaPods"
       },
       {
-        "name": "AFNetworking Templates",
-        "url": "https://github.com/AFNetworking/Xcode-Project-Templates",
-        "description": "Start Your Project Off Right, with CocoaPods & AFNetworking"
-      },
-      {
         "name": "Xcode 4 Plugin",
         "url": "https://github.com/kattrali/Xcode4-Plugin-Template",
         "description": "Project Template for creating a plugin for Xcode 4"


### PR DESCRIPTION
According to [this issue](https://github.com/AFNetworking/Xcode-Project-Templates/issues/12), something about Xcode template format changed in the latest version that somehow causes the target directory to have all of its contents deleted. This is extraordinarily bad.

Since it was already out of date anyway, I'm shutting down the project. 

Please merge this as soon as possible, to reduce the chance of anyone else being affected by this.
