### PR TITLE
Updates url to the git repo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -944,7 +944,7 @@
       },
       {
         "name": "Slack Templates",
-        "url": "https://github.com/slackhq/SlackTextViewController/tree/master/Template",
+        "url": "https://github.com/slackhq/SlackTextViewController",
         "description": "A set of useful templates to quickly start using SlackTextViewController.",
         "screenshot": "https://raw.githubusercontent.com/slackhq/SlackTextViewController/master/Screenshots/screenshot_template.png"
       }


### PR DESCRIPTION
Installation isn't working, when assigning the templates folder of the repo. It seems that pointing to the repo url instead should be good, right?
