### PR TITLE
Add another Solarized Light & Dark theme.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1032,13 +1032,13 @@
         "screenshot": "https://raw.githubusercontent.com/haaakon/Scaffolding/master/screenshot.png"
       },
       {
-        "name": "Solarized Light (Xcode 5+)",
+        "name": "Solarized Light (Tweaked by Stackia, Xcode 5+)",
         "url": "https://raw.githubusercontent.com/stackia/solarized-xcode/master/Solarized%20Light.dvtcolortheme",
         "description": "Enjoy the world's most-popular theme for programming on Xcode. (Tested on Xcode 5+)",
         "screenshot": "https://raw.githubusercontent.com/stackia/solarized-xcode/master/Screenshot_Light.png"
       },
       {
-        "name": "Solarized Dark (Xcode 5+)",
+        "name": "Solarized Dark (Tweaked by Stackia, Xcode 5+)",
         "url": "https://raw.githubusercontent.com/stackia/solarized-xcode/master/Solarized%20Dark.dvtcolortheme",
         "description": "Enjoy the world's most-popular theme for programming on Xcode. (Tested on Xcode 5+)",
         "screenshot": "https://raw.githubusercontent.com/stackia/solarized-xcode/master/Screenshot_Dark.png"


### PR DESCRIPTION
I made another Solarized Light & Dark theme for Xcode. Tested on Xcode 5/6/6.1.
![screenshot_dark](https://cloud.githubusercontent.com/assets/5107241/4832805/415900b2-5f9f-11e4-89e8-62ba459dcbdd.png)
![screenshot_light](https://cloud.githubusercontent.com/assets/5107241/4832806/41dde57a-5f9f-11e4-83ae-e64cb7e406df.png)
