### PR TITLE
Added Empty Application template details.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1018,6 +1018,12 @@
         "name": "Xcode Plugin",
         "url": "https://github.com/kattrali/Xcode-Plugin-Template",
         "description": "Project Template for creating a plugin for Xcode 5+"
+      },
+      {
+        "name": "Xcode Empty Application",
+        "url": "https://github.com/Isuru-Nanayakkara/Xcode-Empty-Application-Template",
+        "description": "Bringing the Empty Application template back to Xcode",
+        "screenshot": "https://raw.githubusercontent.com/Isuru-Nanayakkara/Xcode-Empty-Application-Template/master/screenshot.png"
       }
     ],
     "file_templates": [


### PR DESCRIPTION
In Xcode 6 and onwards, the Empty Application template has been removed. But you can add it back manually. This repo is to automate the process.