### PR TITLE
Submit for SketchExporter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -834,7 +834,7 @@
       {
         "name": "SketchExporter",
         "url": "https://github.com/gliyao/SketchExporter",
-        "description": "Export AppIcon and icons to your Images.xassets (require sketchtool - cli tool for Sektch)",
+        "description": "Export your Sketch AppIcon and icons to your Images.xassets (require sketchtool - cli tool for Sektch)",
         "screenshot": "https://raw.githubusercontent.com/gliyao/SketchExporter/master/SketchExporter.png"
       }
     ],

--- a/packages.json
+++ b/packages.json
@@ -830,6 +830,12 @@
         "name": "PrettyPrintJSON",
         "url": "https://github.com/psobko/PrettyPrintJSON",
         "description": "Pretty print JSON from the console."
+      },
+      {
+        "name": "SketchExporter",
+        "url": "https://github.com/gliyao/SketchExporter",
+        "description": "Export AppIcon and icons to your Images.xassets (require sketchtool - cli tool for Sektch)",
+        "screenshot": "https://raw.githubusercontent.com/gliyao/SketchExporter/master/SketchExporter.png"
       }
     ],
     "color_schemes": [


### PR DESCRIPTION
Hi, this plugin help user export their .sketch assets to Images.xcassets. But it is depend on cli sketchtool.