### PR TITLE
Added reference to LicensedSwiftTemplates file template repo.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1398,6 +1398,11 @@
     ],
     "file_templates": [
       {
+        "name": "Licensed Swift Templates",
+        "url": "https://github.com/leonardosul/LicensedSwiftTemplates",
+        "description": "Swift file templates with choice of open source license placed in the header"
+      }
+      {
         "name": "Aerolitec Templates",
         "url": "https://github.com/Aerolitec/aerolitec-templates",
         "description": "File templates for Aerolitec Coding Standard"

--- a/packages.json
+++ b/packages.json
@@ -1401,7 +1401,7 @@
         "name": "Licensed Swift Templates",
         "url": "https://github.com/leonardosul/LicensedSwiftTemplates",
         "description": "Swift file templates with choice of open source license placed in the header"
-      }
+      },
       {
         "name": "Aerolitec Templates",
         "url": "https://github.com/Aerolitec/aerolitec-templates",


### PR DESCRIPTION
This is a file template plugin that allows selecting an open source license to appear in the header of a Swift file.