### PR TITLE
Remove MiniXcode

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -374,12 +374,6 @@
         "screenshot": "https://raw.githubusercontent.com/yuhua-chen/MCLog/master/MCLogScreenshot.gif"
       },
       {
-        "name": "MiniXcode",
-        "url": "https://github.com/Daij-Djan/MiniXcode",
-        "description": "Plugin that makes it easier to run Xcode without the main toolbar.",
-        "screenshot": "https://raw.githubusercontent.com/Daij-Djan/MiniXcode/master/Screenshot.png"
-      },
-      {
         "name": "NJHMultiTheme",
         "url": "https://github.com/nathanhosselton/NJHMultiTheme",
         "description": "Set separate Xcode themes for Swift and Objective-C source files.",


### PR DESCRIPTION
Remove the plugin OCMiniXcode.

The plugin is un-buildable as-is because the xcodeproj is named `OCMiniXcode.xcodeproj` and the plugin is named `MiniXcode`.
Also, the plugin isn't compatible with any newer version of Xcode since 5.1 and wasn't updated in a year.