### PR TITLE
Added Spec for Open in iTerm plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -431,6 +431,12 @@
         "screenshot": "https://raw.githubusercontent.com/ryanmeisters/Xcode-Plugin-Open-Sublime-Text/master/Misc/OpenInSublimeTextMenu.png"
       },
       {
+        "name": "OpenInITerm",
+        "url": "https://github.com/sathya-me/OpenInITerm.git",
+        "description": "Xcode plugin to reveal files in iTerm.",
+        "screenshot": "https://raw.githubusercontent.com/sathya-me/OpenInITerm/master/demo.png"
+      },
+      {
         "name": "OpenInTerminal",
         "url": "https://github.com/sathya-me/OpenInTerminal.git",
         "description": "Xcode plugin to reveal files in Terminal.",


### PR DESCRIPTION
Added a new package to directly open the locations of files and projects in iTerm. This uses Terminal app as a backup option if iTerm is not installed. 