### PR TITLE
Renaming package to name of .xcodeproj file

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -968,7 +968,7 @@
         "screenshot": "https://raw.githubusercontent.com/Sephiroth87/VariablesViewFullCopy-Xcode/master/screenshot.png"
       },
       {
-        "name": "Insert-Lines",
+        "name": "SublimeShortcuts-ObjC",
         "url": "https://github.com/matrinox/InsertLineXcodePlugin",
         "description": "Covenient inserting lines like in Sublime/Atom. Use command+enter or command+shift+enter to insert and jump to the next or previous line, respectively."
       }


### PR DESCRIPTION
I had a custom, more appropriate name but now I'm changing it to the name of the project (not bothering to rename all the appropriate files). Is it required to have the exact same name? If not, please close this PR for me. Thanks