### PR TITLE
Fixed SYConfigurableVariable name

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1655,7 +1655,7 @@
         "description": "File Templates for Models using the Mantle framework"
       },
       {
-        "name": "ConfigurableVariable",
+        "name": "SYConfigurableVariable",
         "url": "https://github.com/dvkch/SYConfigurableVariable",
         "description": "Create build variables that you will be able to edit easily via the Edit menu in Xcode",
         "screenshot": "https://raw.githubusercontent.com/dvkch/SYConfigurableVariable/master/Sample%20screenshot%202.png"


### PR DESCRIPTION
Having ConfigurableVariable set as name, and ConfigurableVariable.xcworkspace at the root of the git repo doesn't seem to work, project is recognized as a template. Changed all names to match the repo name: SYConfigurableVariable