### PR TITLE
Update OFPlugin to OFXcodeMenu and location

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -439,10 +439,10 @@
         "screenshot": "https://raw.githubusercontent.com/vampirewalk/ObjectGraph-Xcode/master/ObjectGraph.png"
       },
       {
-        "name": "OFPlugin",
-        "url": "https://github.com/admsyn/OFPlugin.git",
+        "name": "OFXcodeMenu",
+        "url": "https://github.com/openframeworks/OFXcodeMenu.git",
         "description": "Plugin for adding OpenFrameworks addons to projects",
-        "screenshot": "https://raw.githubusercontent.com/admsyn/OFPlugin/master/screenshot.jpg"
+        "screenshot": "https://raw.githubusercontent.com/openframeworks/OFXcodeMenu/master/screenshot.jpg"
       },
       {
         "name": "OMColorSense",


### PR DESCRIPTION
Recently, OFPlugin became OFXcodeMenu and switched repositories to be hosted by the @openframeworks organization.

Alcatraz doesn't seem to be handling the redirect to the new location automatically, so this adds the correct (new) location and screenshot, etc.

@admsyn - in response to https://github.com/openframeworks/OFXcodeMenu/issues/40
