### PR TITLE
Update packages.json: New Theme (Prism)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1261,6 +1261,12 @@
         "screenshot": "https://raw.githubusercontent.com/dmcrodrigues/Oceanic-Next-Xcode-Theme/master/Screenshots/Objective-C.png"
       },
       {
+      	"name": "Prism",
+      	"url": "https://raw.github.com/xcorlett/prismtheme-xcode/master/Prism.dvtcolortheme",
+      	"description": "A theme that attempts to mimic the default color scheme from Lea Verou's excellent Prism.js syntax highlighter. Uses Consolas as the default font.",
+      	"screenshot": "https://raw.github.com/xcorlett/prismtheme-xcode/master/xcode-prism-screenshot.png"
+      },
+      {
         "name": "Push Popcorn",
         "url": "https://raw.github.com/andreagelati/Push-Popcorn/master/Push%20Popcorn.dvtcolortheme",
         "description": "A theme made by Andrea Gelati."


### PR DESCRIPTION
Added my Xcode theme, [Prism](https://github.com/xcorlett/prismtheme-xcode). Prism tries to emulate the default color scheme from Lea Verou's excellent [prism.js](http://prismjs.com) syntax highlighter.

<img width="915" alt="xcode-prism-screenshot" src="https://cloud.githubusercontent.com/assets/4478577/10262500/d8189b4a-6965-11e5-93cd-f15a43d1a671.png">