### PR TITLE
update screenshot in Reveal-In-Github plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -583,7 +583,7 @@
         "name": "Reveal-In-Github",
         "url": "https://github.com/lzwjava/Reveal-In-Github",
         "description": "Let you jump to Github History, Blame, PRs, Issues, Notifications of current repo in one second.",
-        "screenshot": "https://cloud.githubusercontent.com/assets/5022872/10864851/a9124530-8035-11e5-8d67-ea73c9156d71.png"
+        "screenshot": "https://cloud.githubusercontent.com/assets/5022872/10865607/a840173e-804b-11e5-93a4-a054743951a7.jpg"
       },
       {
         "name": "RRConstraintsPlugin",


### PR DESCRIPTION
Sorry for this.

Original screenshot is too large, 2796 x 1746.  Made by retina screen, 

Looks like,

![image](https://cloud.githubusercontent.com/assets/5022872/10865628/78d72216-804c-11e5-9377-9d5204a65d95.png)

It's too ugly. Now change to 600x376. 

https://cloud.githubusercontent.com/assets/5022872/10865607/a840173e-804b-11e5-93a4-a054743951a7.jpg

Forgive me...

@jurre 