### PR TITLE
Add IBUnfuck as a package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1770,6 +1770,11 @@
         "name": "Mantle",
         "url": "https://github.com/Ashton-W/Mantle-Xcode-Templates",
         "description": "File Templates for Models using the Mantle framework"
+      },
+      {
+        "name": "IBUnfuck",
+        "url": "https://github.com/Reflejo/IBUnfuck",
+        "description": "Prevents Interface Builder to store half pixels on XIBs and Storyboards"
       }
     ]
   }


### PR DESCRIPTION
After installing this plugin, no rect will contain half pixels. This is useful *only* when using autolayout to prevent Xcode anarchy (it modifies +- 0.5px according to screen scale).